### PR TITLE
Enable CPU boost by default

### DIFF
--- a/modules/secure-cloud-run-core/main.tf
+++ b/modules/secure-cloud-run-core/main.tf
@@ -22,6 +22,7 @@ locals {
     "run.googleapis.com/vpc-access-egress"    = var.vpc_egress_value,
     "run.googleapis.com/network-interfaces"   = var.network_interfaces
     "run.googleapis.com/cpu-throttling"       = var.cpu_throttling
+    "run.googleapis.com/startup-cpu-boost"    = var.cpu_boost
   }
 
   conditional_annotations = {

--- a/modules/secure-cloud-run-core/variables.tf
+++ b/modules/secure-cloud-run-core/variables.tf
@@ -355,3 +355,7 @@ variable "cpu_throttling" {
   default     = true
 }
 
+variable "cpu_boost" {
+  description = "Enable cpu boost"
+  default     = true
+}


### PR DESCRIPTION
Rationale: https://cloud.google.com/blog/products/serverless/announcing-startup-cpu-boost-for-cloud-run--cloud-functions