### PR TITLE
feat: Add gpu_zonal_redundancy_disabled to secure-cloud-run-core

### DIFF
--- a/modules/secure-cloud-run-core/README.md
+++ b/modules/secure-cloud-run-core/README.md
@@ -51,6 +51,7 @@ module "cloud_run_core" {
 | env\_vars | Environment variables. | <pre>list(object({<br>    value = string<br>    name  = string<br>  }))</pre> | `[]` | no |
 | force\_override | Option to force override existing mapping. | `bool` | `false` | no |
 | generate\_revision\_name | Option to enable revision name generation. | `bool` | `true` | no |
+| gpu\_zonal\_redundancy\_disabled | Set to `true` to disable GPU zonal redundancy (avoids requiring GPU zonal-redundancy quota). Only applied when a GPU is configured via `node_selector`. Leave `null` for the Cloud Run default (enabled). | `bool` | `null` | no |
 | image | GAR hosted image URL to deploy. | `string` | n/a | yes |
 | lb\_name | Name for load balancer and associated resources. | `string` | `"tf-cr-lb"` | no |
 | limits | Resource limits to the container. | `map(string)` | `null` | no |

--- a/modules/secure-cloud-run-core/main.tf
+++ b/modules/secure-cloud-run-core/main.tf
@@ -29,6 +29,10 @@ locals {
     secret = {}
   }
 
+  gpu_annotations = (var.node_selector != null && var.gpu_zonal_redundancy_disabled != null) ? {
+    "run.googleapis.com/gpu-zonal-redundancy-disabled" = tostring(var.gpu_zonal_redundancy_disabled)
+  } : {}
+
   secrets = distinct(flatten([
     for secret in var.volumes : [
       for secret_name in secret.secret : [
@@ -86,6 +90,7 @@ module "cloud_run" {
 
   template_annotations = merge(
     local.annotations_for_template,
+    local.gpu_annotations,
     local.conditional_annotations["secret"]
   )
 

--- a/modules/secure-cloud-run-core/metadata.yaml
+++ b/modules/secure-cloud-run-core/metadata.yaml
@@ -217,6 +217,9 @@ spec:
       - name: node_selector
         description: GPU hardware requirements. Set the key `run.googleapis.com/accelerator` to the GPU type (e.g. `nvidia-l4`). Also add `"nvidia.com/gpu"` to `limits` and set `cpu_throttling = false`. [More info](https://cloud.google.com/run/docs/configuring/services/gpu).
         varType: map(string)
+      - name: gpu_zonal_redundancy_disabled
+        description: Set to `true` to disable GPU zonal redundancy (avoids requiring GPU zonal-redundancy quota). Only applied when a GPU is configured via `node_selector`. Leave `null` for the Cloud Run default (enabled).
+        varType: bool
       - name: ports
         description: Port which the container listens to (http1 or h2c).
         varType: |-

--- a/modules/secure-cloud-run-core/variables.tf
+++ b/modules/secure-cloud-run-core/variables.tf
@@ -234,6 +234,12 @@ variable "node_selector" {
   default     = null
 }
 
+variable "gpu_zonal_redundancy_disabled" {
+  description = "Set to `true` to disable GPU zonal redundancy (avoids requiring GPU zonal-redundancy quota). Only applied when a GPU is configured via `node_selector`. Leave `null` for the Cloud Run default (enabled)."
+  type        = bool
+  default     = null
+}
+
 variable "ports" {
   description = "Port which the container listens to (http1 or h2c)."
   type = object({


### PR DESCRIPTION
Allows disabling GPU zonal redundancy via the
run.googleapis.com/gpu-zonal-redundancy-disabled annotation, which is required for projects without GPU zonal-redundancy quota. Only emitted when a GPU is configured via node_selector.